### PR TITLE
Proposed fix for handling C# byte arrays

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -52,6 +52,12 @@ namespace nTsMapper
 					MatchesType = tr => typeof(Object) == tr,
 					DestinationType = "any",
 					DestinationAssignmentTemplate = "{0}"
+				},
+				new TypeMapping
+				{
+					MatchesType = tr => typeof(byte[]) == tr,
+					DestinationType = "string",
+					DestinationAssignmentTemplate = "{0}"
 				}
 			};
 


### PR DESCRIPTION
Proposed fix for handling C# byte arrays.  WebAPI / JSON.net deserialize C# byte arrays into a base64 encoded string, so this fix changes the mapping for byte arrays to use TypeScript strings.
